### PR TITLE
ci: add javadoc doclint config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,7 @@
 						</executions>
 						<configuration>
 							<quiet>true</quiet>
+							<doclint>none</doclint>
 							<additionalparam>-Xdoclint:none</additionalparam>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
Configuration was added to the starter in https://github.com/FlowingCode/AddonStarter23/commit/0daef7ec65e5ae9c6d903ccd97b669de5f07f1ac