### PR TITLE
Version 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
 		<dependency>
 			<groupId>org.vaadin.addons.flowingcode</groupId>
 			<artifactId>grid-helpers</artifactId>
-			<version>0.3.3</version>
+			<version>1.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>Grid Exporter Add-on for Vaadin Flow</description>
 
 	<properties>
-        <vaadin.version>23.1.9</vaadin.version>
+        <vaadin.version>23.3.15</vaadin.version>
         <selenium.version>4.1.2</selenium.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
New minor version upgrading grid-helpers to 1.1.0, which requires Vaadin 23.3.