### PR TITLE
refactor: use StreamResourceWriter instead of InputStreamFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>6.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
 			<version>${poi.version}</version>

--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/BaseStreamResourceWriter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/BaseStreamResourceWriter.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalQuery;
-import com.vaadin.flow.server.InputStreamFactory;
+import com.vaadin.flow.server.StreamResourceWriter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,18 +44,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("serial")
-abstract class BaseInputStreamFactory<T> implements InputStreamFactory {
+abstract class BaseStreamResourceWriter<T> implements StreamResourceWriter {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BaseInputStreamFactory.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseStreamResourceWriter.class);
+
   protected GridExporter<T> exporter;
   protected String template;
 
-  public BaseInputStreamFactory(GridExporter<T> exporter) {
+  public BaseStreamResourceWriter(GridExporter<T> exporter) {
     super();
     this.exporter = exporter;
   }
 
-  public BaseInputStreamFactory(
+  public BaseStreamResourceWriter(
       GridExporter<T> exporter, String customTemplate, String defaultTemplate) {
     super();
     this.exporter = exporter;

--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridExporter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridExporter.java
@@ -268,7 +268,7 @@ public class GridExporter<T> implements Serializable {
   }
 
   public StreamResource getDocxStreamResource(String template) {
-    return new StreamResource(fileName + ".docx", new DocxInputStreamFactory<>(this, template));
+    return new StreamResource(fileName + ".docx", new DocxStreamResourceWriter<>(this, template));
   }
 
   public StreamResource getPdfStreamResource() {
@@ -276,11 +276,11 @@ public class GridExporter<T> implements Serializable {
   }
 
   public StreamResource getPdfStreamResource(String template) {
-    return new StreamResource(fileName + ".pdf", new PdfInputStreamFactory<>(this, template));
+    return new StreamResource(fileName + ".pdf", new PdfStreamResourceWriter<>(this, template));
   }
 
   public StreamResource getCsvStreamResource() {
-    return new StreamResource(fileName + ".csv", new CsvInputStreamFactory<>(this));
+    return new StreamResource(fileName + ".csv", new CsvStreamResourceWriter<>(this));
   }
 
   public StreamResource getExcelStreamResource() {
@@ -288,7 +288,7 @@ public class GridExporter<T> implements Serializable {
   }
 
   public StreamResource getExcelStreamResource(String template) {
-    return new StreamResource(fileName + ".xlsx", new ExcelInputStreamFactory<>(this, template));
+    return new StreamResource(fileName + ".xlsx", new ExcelStreamResourceWriter<>(this, template));
   }
 
   public String getTitle() {


### PR DESCRIPTION
Use StreamResourceWriter instead of InputStreamFactory + Thread + PipedInput/OutputStream + implicit StreamResource pipe. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced export functionality for GridExporter, supporting direct writing to OutputStream for CSV, DOCX, PDF, and Excel formats.

- **Refactor**
  - Updated internal class names and method signatures to improve clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->