### PR TITLE
Fix problem when exporting grids with only one column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 		<dependency>
 			<groupId>org.vaadin.addons.flowingcode</groupId>
 			<artifactId>grid-helpers</artifactId>
-			<version>1.1.1</version>
+			<version>1.3.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/ExcelStreamResourceWriter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/ExcelStreamResourceWriter.java
@@ -98,7 +98,7 @@ class ExcelStreamResourceWriter<T> extends BaseStreamResourceWriter<T> {
       List<Pair<String, Column<T>>> headers = getGridHeaders(exporter.grid);
 
       fillHeaderOrFooter(sheet, cell, headers, true);
-      if (exporter.autoMergeTitle && titleCell != null) {
+      if (exporter.autoMergeTitle && titleCell != null && exporter.getColumns().size()>1) {
         sheet.addMergedRegion(new CellRangeAddress(titleCell.getRowIndex(), titleCell.getRowIndex(),
             titleCell.getColumnIndex(), titleCell.getColumnIndex() + headers.size() - 1));
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the dependency for `grid-helpers` to version 1.3.2, which may include new features and improvements.
  
- **Bug Fixes**
	- Enhanced the logic for merging title cells in Excel exports, ensuring better control when generating Excel files with multiple columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->