### PR TITLE
refactor: move global concurrent settings to a separate class

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterConcurrentSettings.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterConcurrentSettings.java
@@ -1,0 +1,104 @@
+package com.flowingcode.vaadin.addons.gridexporter;
+
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.shared.Registration;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provides global settings for managing concurrent downloads in {@link GridExporter}.
+ * <p>
+ * This class allows for setting limits on concurrent downloads, configuring timeouts for acquiring
+ * download permits, and adding global listeners for concurrent download timeout events.
+ * </p>
+ */
+public class GridExporterConcurrentSettings {
+
+  private static long concurrentDownloadTimeoutNanos = 0L;
+
+  private static final List<SerializableConsumer<ConcurrentDownloadTimeoutEvent>> globalDownloadTimeoutListeners =
+      new CopyOnWriteArrayList<>();
+
+  static List<SerializableConsumer<ConcurrentDownloadTimeoutEvent>> getGlobalDownloadTimeoutListeners() {
+    return Collections.unmodifiableList(globalDownloadTimeoutListeners);
+  }
+
+  /**
+   * Sets the limit for the {@linkplain GridExporter#setConcurrentDownloadCost(float) cost of
+   * concurrent downloads}. If all the downloads have a cost of {@link GridExporter#DEFAULT_COST},
+   * the limit represents the number of concurrent downloads that are allowed.
+   * <p>
+   * Finite limits are capped to {@link GridExporter#MAX_COST} (32767). If the limit is
+   * {@link Float#POSITIVE_INFINITY POSITIVE_INFINITY}, concurrent downloads will not be limited.
+   *
+   * @param limit the maximum cost of concurrent downloads allowed
+   * @throws IllegalArgumentException if the limit is zero or negative.
+   */
+  public static void setConcurrentDownloadLimit(float limit) {
+    ConcurrentStreamResourceWriter.setLimit(limit);
+  }
+
+  /**
+   * Returns the limit for the number of concurrent downloads.
+   *
+   * @return the limit for the number of concurrent downloads, or {@link Float#POSITIVE_INFINITY} if
+   *         concurrent downloads are not limited.
+   */
+  public static float getConcurrentDownloadLimit() {
+    return ConcurrentStreamResourceWriter.getLimit();
+  }
+
+  /**
+   * Configures the behavior of the stream operation when the UI changes during execution.
+   *
+   * @param failOnUiChange If {@code true}, the operation will throw an {@link IOException} if the
+   *        UI changes (e.g., becomes detached) after acquiring the semaphore. If {@code false}, the
+   *        operation will proceed regardless of any UI changes.
+   */
+  public static void setFailOnUiChange(boolean failOnUiChange) {
+    ConcurrentStreamResourceWriter.setFailOnUiChange(failOnUiChange);
+  }
+
+  /**
+   * Sets the timeout for acquiring a permit to start a download when the
+   * {@linkplain #setConcurrentDownloadLimit(float) maximum number of concurrent downloads} is
+   * reached. If the timeout is less than or equal to zero, the downloads will fail immediately if
+   * no enough permits can be acquired.
+   *
+   * This timeout is crucial for preventing the system from hanging indefinitely while waiting for
+   * available resources. If the timeout expires before a permit can be acquired, the download is
+   * cancelled.
+   *
+   * @param timeout the maximum time to wait for a permit
+   * @param unit the time unit of the {@code timeout} argument
+   */
+  public static void setConcurrentDownloadTimeout(long timeout, TimeUnit unit) {
+    concurrentDownloadTimeoutNanos = unit.toNanos(timeout);
+  }
+
+  public static long getConcurrentDownloadTimeout(TimeUnit unit) {
+    return unit.convert(concurrentDownloadTimeoutNanos, TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Adds a global listener for concurrent download timeout events.
+   * <p>
+   * The listener will be called whenever a concurrent download timeout event occurs.
+   * <p>
+   * Note that instance-specific listeners take precedence over global listeners. If an instance
+   * listener stops the event propagation by calling
+   * {@link ConcurrentDownloadTimeoutEvent#stopPropagation() stopPropagation()}, the global
+   * listeners will not be notified.
+   *
+   * @param listener the listener to be added
+   * @return a {@link Registration} object that can be used to remove the listener
+   */
+  public static Registration addGlobalConcurrentDownloadTimeoutEvent(
+      SerializableConsumer<ConcurrentDownloadTimeoutEvent> listener) {
+    globalDownloadTimeoutListeners.add(0, listener);
+    return () -> globalDownloadTimeoutListeners.remove(listener);
+  }
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/gridexporter/VaadinServiceInitListenerImpl.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridexporter/VaadinServiceInitListenerImpl.java
@@ -10,17 +10,17 @@ public class VaadinServiceInitListenerImpl implements VaadinServiceInitListener 
 
   @Override
   public void serviceInit(ServiceInitEvent event) {
-    GridExporter.setConcurrentDownloadLimit(10);
+    GridExporterConcurrentSettings.setConcurrentDownloadLimit(10);
 
     // begin-block setConcurrentDownloadTimeout
-    GridExporter.setConcurrentDownloadTimeout(5, TimeUnit.SECONDS);
-    GridExporter.addGlobalConcurrentDownloadTimeoutEvent(ev -> {
+    GridExporterConcurrentSettings.setConcurrentDownloadTimeout(5, TimeUnit.SECONDS);
+    GridExporterConcurrentSettings.addGlobalConcurrentDownloadTimeoutEvent(ev -> {
       Notification.show("System is busy. Please try again later.")
           .addThemeVariants(NotificationVariant.LUMO_ERROR);
     });
     // end-block
 
-    GridExporter.setFailOnUiChange(true);
+    GridExporterConcurrentSettings.setFailOnUiChange(true);
 
   }
 

--- a/src/test/java/com/flowingcode/vaadin/addons/gridexporter/test/ConcurrentExportTests.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridexporter/test/ConcurrentExportTests.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import com.flowingcode.vaadin.addons.gridexporter.ConfigurableConcurrentStreamResourceWriter;
 import com.flowingcode.vaadin.addons.gridexporter.GridExporter;
+import com.flowingcode.vaadin.addons.gridexporter.GridExporterConcurrentSettings;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.StreamResourceWriter;
 import com.vaadin.flow.server.VaadinService;
@@ -80,7 +81,7 @@ public class ConcurrentExportTests {
 
   @Before
   public void before() {
-    GridExporter.setFailOnUiChange(false);
+    GridExporterConcurrentSettings.setFailOnUiChange(false);
     barrier = null;
     if (!lock.tryLock()) {
       throw new IllegalStateException(
@@ -379,7 +380,7 @@ public class ConcurrentExportTests {
 
   @Test(timeout = TEST_TIMEOUT)
   public void testFailOnUiClose() throws InterruptedException, BrokenBarrierException {
-    GridExporter.setFailOnUiChange(true);
+    GridExporterConcurrentSettings.setFailOnUiChange(true);
     ConcurrentStreamResourceWriter.setLimit(1);
 
     initializeCyclicBarrier(2);


### PR DESCRIPTION
I moved the new API introduced in #125, #128 and #129 to a separate class, so that `GridExporter` does not gain so many methods. (The global settings, now in `GridExporterConcurrentSettings` would likely be used only from vaadin service initializer.) 

Close #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new class for managing concurrent download settings, enhancing control over download behavior.
	- Added methods to configure download limits, timeouts, and UI change handling.

- **Bug Fixes**
	- Improved robustness in handling concurrent downloads by centralizing configuration management.

- **Refactor**
	- Removed static fields and methods from the `GridExporter` class to streamline download settings management.
	- Updated references in service initialization and tests to utilize the new settings class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->