### PR TITLE
deprecate: deprecate a public attribute

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/DocxStreamResourceWriter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/DocxStreamResourceWriter.java
@@ -167,6 +167,7 @@ class DocxStreamResourceWriter<T> extends BaseStreamResourceWriter<T> {
             Iterator<Column<T>> iterator = exporter.getColumns().iterator();
             while (iterator.hasNext()) {
               iterator.next();
+              // preserve increment for deprecated attribute
               exporter.totalcells = exporter.totalcells + 1;
               currentRow.createCell();
             }

--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridExporter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridExporter.java
@@ -124,6 +124,8 @@ public class GridExporter<T> implements Serializable {
 
   SerializableSupplier<String> nullValueSupplier;
 
+  /** @deprecated. This attribute is incremented only when exporting DOCX, but it's never reset. */
+  @Deprecated(since = "2.5.0", forRemoval = true)
   public int totalcells = 0;
 
   private ButtonsAlignment buttonsAlignment = ButtonsAlignment.RIGHT;


### PR DESCRIPTION
This should be merged after #143 which already increments the POM version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added documentation to clarify the handling of the `totalcells` variable in the export process.
  
- **Deprecations**
	- Marked the `totalcells` variable as deprecated, signaling its phased-out usage in future versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->