### PR TITLE
fix: update docx4j version and add required maven deps so that pdf export works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,23 +136,28 @@
 		</dependency>
 		<dependency>
 		    <groupId>org.docx4j</groupId>
-		    <artifactId>docx4j-JAXB-Internal</artifactId>
-		    <version>8.3.8</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.docx4j</groupId>
 		    <artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
-		    <version>8.3.8</version>
+		    <version>11.5.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.docx4j</groupId>
 		    <artifactId>docx4j-JAXB-MOXy</artifactId>
-		    <version>8.3.8</version>
+		    <version>11.5.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.docx4j</groupId>
 		    <artifactId>docx4j-export-fo</artifactId>
-		    <version>8.3.8</version>
+		    <version>11.5.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.27.1</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.16.1</version>
 		</dependency>
 		<dependency>
 		   <groupId>com.flowingcode.addons</groupId>
@@ -365,7 +370,7 @@
 							<doclint>none</doclint>
 							<failOnWarnings>true</failOnWarnings>
 							<links>
-								<link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>								
+								<link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
 							</links>
 						</configuration>
 					</plugin>
@@ -527,7 +532,7 @@
 		</profile>
 		<profile>
 			<id>demo-jar</id>
-			<build>		
+			<build>
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -551,7 +556,7 @@
 					</plugin>
 				</plugins>
 			</build>
-		</profile>		
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
Fixes #136

- Updated docx4j maven deps to latest version which adds support for java 11
- Added updated versions of apache commons-compress and commons-io which was required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced document processing capabilities with updated dependencies for better performance and functionality.
	- Added support for additional libraries to improve file handling and compression.

- **Bug Fixes**
	- Removed obsolete dependency to streamline the application and reduce potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->