### PR TITLE
test: set timeout to 10 seconds

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/gridexporter/test/ConcurrentExportTests.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridexporter/test/ConcurrentExportTests.java
@@ -56,7 +56,7 @@ import org.junit.Test;
 @net.jcip.annotations.NotThreadSafe
 public class ConcurrentExportTests {
 
-  private static final int TEST_TIMEOUT = 5000;
+  private static final int TEST_TIMEOUT = 10000;
 
   private static Matcher<Throwable> throwsInterruptedByTimeout() {
     return Matchers.instanceOf(InterruptedByTimeoutException.class);


### PR DESCRIPTION
This test is flaky. Try a longer timeout to see if it stabilizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Extended the timeout duration for automated tests to allow for longer execution times, enhancing overall test stability and reducing premature test failures. This internal improvement does not impact any user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->