### PR TITLE
docs: update online demo link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is an addon that allows to export Vaadin's grid data to some formats like E
 
 ## Online demo
 
-[Online demo here](http://addonsv23.flowingcode.com/gridexporter)
+[Online demo here](https://addonsv24.flowingcode.com/gridexporter)
 
 ## Download release
 


### PR DESCRIPTION
Demo link was still pointing to Vaadin 23 version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the online demo link in the README to use a secure HTTPS address and the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->