### PR TITLE
build: upgrade vaadin to 23.3.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>Grid Exporter Add-on for Vaadin Flow</description>
 
 	<properties>
-        <vaadin.version>23.3.15</vaadin.version>
+        <vaadin.version>23.3.35</vaadin.version>
         <selenium.version>4.1.2</selenium.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
Upgrade vaadin to 23.3.35 in order to get rid of a managed dependency to kubernetes-kit-starter:1.0-SNAPSHOT (that was actually fixed in 23.3.17, but since 23.3 has already reached EOL, let's use the last release)