### PR TITLE
fix: fix duplicate jaxb-core dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ target
 .settings
 .project
 .classpath
+.eclipse
+.vaadin
 webpack.generated.js
 package-lock.json
 package.json

--- a/pom.xml
+++ b/pom.xml
@@ -150,10 +150,16 @@
 		    <version>11.5.0</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.docx4j</groupId>
-		    <artifactId>docx4j-JAXB-MOXy</artifactId>
-		    <version>11.5.0</version>
-		</dependency>
+	    <groupId>org.docx4j</groupId>
+	    <artifactId>docx4j-JAXB-MOXy</artifactId>
+	    <version>11.5.0</version>
+	    <exclusions>
+	        <exclusion>
+	            <groupId>com.sun.xml.bind</groupId>
+	            <artifactId>jaxb-core</artifactId>
+	        </exclusion>
+	    </exclusions>
+	</dependency>
 		<dependency>
 		    <groupId>org.docx4j</groupId>
 		    <artifactId>docx4j-export-fo</artifactId>


### PR DESCRIPTION
Close #187

This PR resolves the duplicate `jaxb-core-4.0.6.jar` dependency issue that prevented users from upgrading to version 2.5.x when building WAR files with Gradle. The problem occurred because both `docx4j-JAXB-ReferenceImpl` and `docx4j-JAXB-MOXy` transitively included different implementations of the same JAXB core library under different Maven group IDs (`org.glassfish.jaxb:jaxb-core` and `com.sun.xml.bind:jaxb-core`).

The fix adds a Maven exclusion to the `docx4j-JAXB-MOXy` dependency, excluding `com.sun.xml.bind:jaxb-core` while keeping the GlassFish reference implementation. This change has been verified with a clean dependency tree, successful build, all unit tests passing and also manual testing of the demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added additional ignore patterns to the repository to reduce clutter in IDEs and tooling.
  * Refined project dependency management by excluding a transitive runtime dependency from the build configuration to improve resolution and build stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FlowingCode/GridExporterAddon/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->