### PR TITLE
fix(demo): wire basic demo zip button to a real DownloadHandler

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterDemo.java
@@ -34,7 +34,10 @@ import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -42,6 +45,8 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.apache.poi.EncryptedDocumentException;
 
 @DemoSource
@@ -98,9 +103,37 @@ public class GridExporterDemo extends Div {
     shareSelect.setItems("Whatsapp", "Facebook", "X (Twitter)");
     shareSelect.setWidth("120px");
     
+    DownloadHandler zipHandler = event -> {
+      String base = exporter.getFileName();
+      event.setFileName(base + ".zip");
+      event.setContentType("application/zip");
+      try (ZipOutputStream zos = new ZipOutputStream(event.getOutputStream())) {
+        // Inner writers may close their wrapper streams; shield the ZipOutputStream from that
+        // while still flushing any pending writes.
+        OutputStream nonClosing = new FilterOutputStream(zos) {
+          @Override
+          public void close() throws IOException {
+            flush();
+          }
+        };
+        zos.putNextEntry(new ZipEntry(base + ".xlsx"));
+        new ExcelStreamResourceWriter<>(exporter, null).accept(nonClosing, event.getSession());
+        zos.closeEntry();
+        zos.putNextEntry(new ZipEntry(base + ".docx"));
+        new DocxStreamResourceWriter<>(exporter, null).accept(nonClosing, event.getSession());
+        zos.closeEntry();
+        zos.putNextEntry(new ZipEntry(base + ".pdf"));
+        new PdfStreamResourceWriter<>(exporter, null).accept(nonClosing, event.getSession());
+        zos.closeEntry();
+        zos.putNextEntry(new ZipEntry(base + ".csv"));
+        new CsvStreamResourceWriter<>(exporter).accept(nonClosing, event.getSession());
+        zos.closeEntry();
+      }
+    };
+
     Anchor zipLink = new Anchor("", FontAwesome.Regular.FILE_ZIPPER.create());
+    zipLink.setHref(zipHandler);
     zipLink.setTitle("Download zip file");
-    zipLink.getElement().setAttribute("download", true);
 
     exporter.setFooterToolbarItems(
         List.of(new FooterToolbarItem(zipLink, FooterToolbarItemPosition.EXPORT_BUTTON),


### PR DESCRIPTION
The "Download zip file" anchor in GridExporterDemo was created with an empty href (new Anchor("", icon) + download=true), so clicking it caused the browser to save the current page's HTML instead of a zip.

The fix in this PR, replaces the empty href with a DownloadHandler that streams a ZIP of the four exported formats (xlsx, docx, pdf, csv) on demand. 

Close #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * ZIP export now bundles multiple formats (XLSX, DOCX, PDF, CSV) into a single downloadable archive for convenient multi-format exports.
  * Downloads are streamed from the server for a smoother, more reliable download experience.

* **Bug Fixes**
  * Improved ZIP download handling to prevent premature stream closure and ensure all included files are delivered intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FlowingCode/GridExporterAddon/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->