### PR TITLE
Correct header rendering for joined columns

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/BaseStreamResourceWriter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/BaseStreamResourceWriter.java
@@ -103,9 +103,11 @@ abstract class BaseStreamResourceWriter<T> implements StreamResourceWriter {
   private GridHeader<T> getGridHeader(Grid<T> grid, Column<T> column) {
       List<String> headerTexts = new ArrayList<>();
       List<HeaderRow> headerRows = grid.getHeaderRows();
-      for (HeaderRow headerRow : headerRows) {
-        String headerText = renderHeaderCellTextContent(grid, headerRow, column);
-          headerTexts.add(headerText);
+      int lastIndex = headerRows.size() - 1;
+      for (int i = 0; i < headerRows.size(); i++) {
+        boolean isLastRow = (i == lastIndex);
+        String headerText = renderHeaderCellTextContent(grid, headerRows.get(i), column, isLastRow);
+        headerTexts.add(headerText);
       }
       return new GridHeader<>(headerTexts, column);
   }
@@ -132,8 +134,11 @@ abstract class BaseStreamResourceWriter<T> implements StreamResourceWriter {
     return value;
   }
 
-  private String renderHeaderCellTextContent(Grid<T> grid, HeaderRow headerRow, Column<T> column) {
-    String header = (String) ComponentUtil.getData(column, GridExporter.COLUMN_HEADER);
+  private String renderHeaderCellTextContent(Grid<T> grid, HeaderRow headerRow, Column<T> column,
+      boolean isLastRow) {
+    String header = isLastRow
+        ? (String) ComponentUtil.getData(column, GridExporter.COLUMN_HEADER)
+        : null;
 
     if (Strings.isBlank(header)) {
       HeaderCell headerCell = headerRow.getCell(column);

--- a/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridHeader.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridexporter/GridHeader.java
@@ -14,7 +14,7 @@ final class GridHeader<T> implements GridHeaderOrFooter<T> {
 
   @Override
   public String getText() {
-    return texts.get(0);
+    return texts.get(texts.size() - 1);
   }
 
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterDemoView.java
@@ -40,6 +40,7 @@ public class GridExporterDemoView extends TabbedDemo {
     addDemo(GridExporterHierarchicalDataDemo.class);
     addDemo(GridExporterBigDatasetDemo.class);
     addDemo(GridExporterMultipleHeaderRowsDemo.class);
+    addDemo(GridExporterJoinedHeadersWithCustomHeaderDemo.class);
     setSizeFull();
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterJoinedHeadersWithCustomHeaderDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridexporter/GridExporterJoinedHeadersWithCustomHeaderDemo.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * Grid Exporter Add-on
+ * %%
+ * Copyright (C) 2022 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.gridexporter;
+
+import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.github.javafaker.Faker;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@DemoSource
+@PageTitle("Joined Headers with Custom Header")
+@Route(value = "gridexporter/joined-custom-header", layout = GridExporterDemoView.class)
+@SuppressWarnings("serial")
+public class GridExporterJoinedHeadersWithCustomHeaderDemo extends Div {
+
+  public GridExporterJoinedHeadersWithCustomHeaderDemo() {
+    Grid<Person> grid = new Grid<>(Person.class);
+    grid.removeAllColumns();
+
+    Column<Person> firstNameCol = grid.addColumn("name").setHeader("First Name");
+    Column<Person> lastNameCol = grid.addColumn("lastName").setHeader("Last Name");
+
+    Faker faker = FakerInstance.get();
+    List<Person> people = IntStream.range(0, 20)
+        .mapToObj(i -> new Person(faker.name().firstName(), faker.name().lastName(),
+            faker.number().numberBetween(15, 50),
+            faker.number().randomDouble(2, 10000, 100000)))
+        .collect(Collectors.toList());
+    grid.setItems(people);
+
+    HeaderRow joinedHeaderRow = grid.prependHeaderRow();
+    Div joinedCell = new Div("Full name");
+    joinedCell.getStyle().set("text-align", "center");
+    joinedHeaderRow.join(firstNameCol, lastNameCol).setComponent(joinedCell);
+
+    GridExporter<Person> exporter = GridExporter.createFor(grid);
+    exporter.setTitle("People information");
+
+    // Custom headers are applied only to the header row closest to the data.
+    // CSV/DOCX/PDF export this single row; Excel keeps the joined "Full name" above it.
+    exporter.setCustomHeader(firstNameCol, "Given name");
+    exporter.setCustomHeader(lastNameCol, "Family name");
+
+    grid.setWidthFull();
+    setSizeFull();
+    add(grid);
+  }
+}


### PR DESCRIPTION
Close #190 

CSV/DOCX/PDF were always rendering the topmost header row, which for joined headers produced the joined-cell text instead of the actual column header. They now use the header row closest to the data, honoring `setCustomHeader` if set. In Excel, `setCustomHeader` was being applied to every header row (duplicating the value across joined rows); it now applies only to the row closest to the data. A new demo covers the issue's scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-level header rows in grid exports, enabling grouped or hierarchical column headers.
  * Custom header text can now be configured on a per-column basis; these settings apply to the header row immediately adjacent to the exported data.
  * Multi-level header behavior varies across different export formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FlowingCode/GridExporterAddon/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->