### PR TITLE
build: upgrade lombok to 1.18.40 with support for Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<drivers.dir>${project.basedir}/drivers</drivers.dir>
 		<jetty.version>11.0.26</jetty.version>
 		<poi.version>5.2.3</poi.version>
+		<lombok.version>1.18.40</lombok.version>
 	</properties>
 
 	<organization>
@@ -120,7 +121,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.34</version>
+			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -237,6 +238,20 @@
 	    <defaultGoal>jetty:run</defaultGoal>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.13.0</version>
+					<configuration>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
+					</configuration>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
See https://github.com/FlowingCode/AddonsInternal/issues/202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Lombok tooling version to 1.18.40.
  * Improved build configuration to ensure Lombok annotation processing is applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->